### PR TITLE
Rename therapist-specialty pivot table

### DIFF
--- a/app/Models/Especialidad.php
+++ b/app/Models/Especialidad.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Especialidad extends Model
 {
@@ -12,8 +13,13 @@ class Especialidad extends Model
 
     protected $fillable = ['nombre'];
 
-    public function terapeutas()
+    public function terapeutas(): BelongsToMany
     {
-        return $this->belongsToMany(Terapeuta::class, 'terapeuta_especialidades', 'especialidad_id', 'terapeuta_id');
+        return $this->belongsToMany(
+            Terapeuta::class,
+            'terapeuta_especialidad',
+            'especialidad_id',
+            'terapeuta_id'
+        );
     }
 }

--- a/app/Models/Terapeuta.php
+++ b/app/Models/Terapeuta.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Terapeuta extends Model
 {
@@ -28,9 +29,14 @@ class Terapeuta extends Model
         return $this->belongsTo(Usuario::class, 'id');
     }
 
-    public function especialidades()
+    public function especialidades(): BelongsToMany
     {
-        return $this->belongsToMany(Especialidad::class, 'terapeuta_especialidad', 'terapeuta_id', 'especialidad_id');
+        return $this->belongsToMany(
+            Especialidad::class,
+            'terapeuta_especialidad',
+            'terapeuta_id',
+            'especialidad_id'
+        );
     }
 
     public function experiencias()

--- a/app/Models/TerapeutaEspecialidad.php
+++ b/app/Models/TerapeutaEspecialidad.php
@@ -9,7 +9,7 @@ class TerapeutaEspecialidad extends Pivot
     protected $table = 'terapeuta_especialidad';
 
     protected $fillable = [
-        'TerapeutaId',
-        'EspecialidadId',
+        'terapeuta_id',
+        'especialidad_id',
     ];
 }

--- a/database/migrations/2025_08_04_000002_rename_terapeuta_especialidads_table.php
+++ b/database/migrations/2025_08_04_000002_rename_terapeuta_especialidads_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('terapeuta_especialidads')) {
+            Schema::rename('terapeuta_especialidads', 'terapeuta_especialidad');
+        }
+
+        if (Schema::hasTable('terapeuta_especialidad')) {
+            if (Schema::hasColumn('terapeuta_especialidad', 'TerapeutaId')) {
+                Schema::table('terapeuta_especialidad', function (Blueprint $table) {
+                    $table->renameColumn('TerapeutaId', 'terapeuta_id');
+                });
+            }
+
+            if (Schema::hasColumn('terapeuta_especialidad', 'EspecialidadId')) {
+                Schema::table('terapeuta_especialidad', function (Blueprint $table) {
+                    $table->renameColumn('EspecialidadId', 'especialidad_id');
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('terapeuta_especialidad')) {
+            if (Schema::hasColumn('terapeuta_especialidad', 'especialidad_id')) {
+                Schema::table('terapeuta_especialidad', function (Blueprint $table) {
+                    $table->renameColumn('especialidad_id', 'EspecialidadId');
+                });
+            }
+
+            if (Schema::hasColumn('terapeuta_especialidad', 'terapeuta_id')) {
+                Schema::table('terapeuta_especialidad', function (Blueprint $table) {
+                    $table->renameColumn('terapeuta_id', 'TerapeutaId');
+                });
+            }
+
+            Schema::rename('terapeuta_especialidad', 'terapeuta_especialidads');
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- rename `terapeuta_especialidads` pivot table to `terapeuta_especialidad`
- align Terapeuta/Especialidad models with new pivot table and keys
- update pivot model fillable fields

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan migrate --no-interaction` *(fails: vendor/autoload.php not found)*
- `php artisan test --no-interaction` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890f2ec5f84832f91efde89cdb1ce64